### PR TITLE
NSString+UAGithubEngineUtilities updated to properly parse returned date formats.

### DIFF
--- a/NSString+UAGithubEngineUtilities.m
+++ b/NSString+UAGithubEngineUtilities.m
@@ -21,9 +21,14 @@
 	if ([[self substringWithRange:NSMakeRange(10, 1)] isEqualToString:@"T"])
 	{
 		if ([[self substringWithRange:NSMakeRange([self length] - 1, 1)] isEqualToString:@"Z"])
-			// eg 2010-05-23T21:26:03.921Z (UTC with milliseconds)
 		{
-			[df setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
+			// eg 2010-05-23T21:26:03.921Z (UTC with milliseconds)
+			if([[self substringWithRange:NSMakeRange(19, 1)] isEqualToString:@"."]){
+				[df setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
+			// eg 2010-05-23T21:26:03Z (UTC without milliseconds)
+			} else {
+				[df setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+			}
 		}
 		else 
 			// eg 2010-04-07T12:50:15-07:00


### PR DESCRIPTION
NSString+UAGithubEngineUtilities now properly parses date formats returned from Github by searchUsers:byEmail: in UAGithubEngine when not searching by email address.
