### PR TITLE
Altered .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,10 @@
 
 build/
 
-*.pbxuser
-*.perspective
-*.perspectivev3
-
-*.mode1v3
-*.mode2v3
-/UAGithubEngine.xcodeproj/xcuserdata/owainhunt.xcuserdatad/xcschemes/UAGithubEngine.xcscheme
-/UAGithubEngine.xcodeproj/project.xcworkspace/xcuserdata/owainhunt.xcuserdatad/UserInterfaceState.xcuserstate
-/UAGithubEngine.xcodeproj/xcuserdata/mlussier.xcuserdatad/
+*.xcodeproj/*.pbxuser
+*.xcodeproj/*.perspective
+*.xcodeproj/*.perspectivev3
+*.xcodeproj/*.mode1v3
+*.xcodeproj/*.mode2v3
+*.xcodeproj/project.xcworkspace/xcuserdata/
+*.xcodeproj/xcuserdata/

--- a/Extensions/NSScanner_Extensions.m
+++ b/Extensions/NSScanner_Extensions.m
@@ -45,7 +45,7 @@ return([[self string] characterAtIndex:[self scanLocation]]);
 
 - (unichar)scanCharacter
 {
-unsigned theScanLocation = [self scanLocation];
+NSUInteger theScanLocation = [self scanLocation];
 unichar theCharacter = [[self string] characterAtIndex:theScanLocation];
 [self setScanLocation:theScanLocation + 1];
 return(theCharacter);
@@ -53,7 +53,7 @@ return(theCharacter);
 
 - (BOOL)scanCharacter:(unichar)inCharacter
 {
-unsigned theScanLocation = [self scanLocation];
+NSUInteger theScanLocation = [self scanLocation];
 if ([[self string] characterAtIndex:theScanLocation] == inCharacter)
 	{
 	[self setScanLocation:theScanLocation + 1];
@@ -65,7 +65,7 @@ else
 
 - (void)backtrack:(unsigned)inCount
 {
-unsigned theScanLocation = [self scanLocation];
+NSUInteger theScanLocation = [self scanLocation];
 if (inCount > theScanLocation)
 	[NSException raise:NSGenericException format:@"Backtracked too far."];
 [self setScanLocation:theScanLocation - inCount];

--- a/NSData+Base64.m
+++ b/NSData+Base64.m
@@ -88,18 +88,19 @@ void *NewBase64Decode(
 		//
 		// Accumulate 4 valid characters (ignore everything else)
 		//
-		unsigned char accumulated[BASE64_UNIT_SIZE];
+		NSUInteger accumulated = 0;
 		size_t accumulateIndex = 0;
 		while (i < length)
 		{
 			unsigned char decode = base64DecodeLookup[inputBuffer[i++]];
 			if (decode != xx)
 			{
-				accumulated[accumulateIndex] = decode;
-				accumulateIndex++;
+				accumulated |= decode;
+				accumulated <<= 6;
 				
 				if (accumulateIndex == BASE64_UNIT_SIZE)
 				{
+                    accumulated >>= 6;
 					break;
 				}
 			}
@@ -108,9 +109,10 @@ void *NewBase64Decode(
 		//
 		// Store the 6 bits from each of the 4 characters as 3 bytes
 		//
-		outputBuffer[j] = (accumulated[0] << 2) | (accumulated[1] >> 4);
-		outputBuffer[j + 1] = (accumulated[1] << 4) | (accumulated[2] >> 2);
-		outputBuffer[j + 2] = (accumulated[2] << 6) | accumulated[3];
+		outputBuffer[j + 2] = accumulated & 0xff;
+		outputBuffer[j + 1] = (accumulated >>= 8) & 0xff;
+		outputBuffer[j] = (accumulated >>= 8) & 0xff;
+        NSCAssert (accumulated == 0, @"Did not drain entire accumulated value");
 		j += accumulateIndex - 1;
 	}
 	

--- a/UAGitHubAPI/UAGitHubAPI-Info.plist
+++ b/UAGitHubAPI/UAGitHubAPI-Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>com.underscore.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/UAGitHubAPI/UAGitHubAPI-Prefix.pch
+++ b/UAGitHubAPI/UAGitHubAPI-Prefix.pch
@@ -1,0 +1,7 @@
+//
+// Prefix header for all source files of the 'UAGitHubAPI' target in the 'UAGitHubAPI' project
+//
+
+#ifdef __OBJC__
+    #import <Cocoa/Cocoa.h>
+#endif

--- a/UAGitHubAPI/en.lproj/InfoPlist.strings
+++ b/UAGitHubAPI/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/UAGitHubAPITests/UAGitHubAPITests-Info.plist
+++ b/UAGitHubAPITests/UAGitHubAPITests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.strawberrycat.lib.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/UAGitHubAPITests/UAGitHubAPITests-Prefix.pch
+++ b/UAGitHubAPITests/UAGitHubAPITests-Prefix.pch
@@ -1,0 +1,7 @@
+//
+// Prefix header for all source files of the 'UAGitHubAPITests' target in the 'UAGitHubAPITests' project
+//
+
+#ifdef __OBJC__
+    #import <Cocoa/Cocoa.h>
+#endif

--- a/UAGitHubAPITests/UAGitHubAPITests.h
+++ b/UAGitHubAPITests/UAGitHubAPITests.h
@@ -1,0 +1,17 @@
+//
+//  UAGitHubAPITests.h
+//  UAGitHubAPITests
+//
+//  Created by Philip Willoughby on 29/04/2011.
+//  Copyright 2011 StrawberryCat. All rights reserved.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+
+@interface UAGitHubAPITests : SenTestCase {
+@private
+    
+}
+
+@end

--- a/UAGitHubAPITests/UAGitHubAPITests.m
+++ b/UAGitHubAPITests/UAGitHubAPITests.m
@@ -1,0 +1,33 @@
+//
+//  UAGitHubAPITests.m
+//  UAGitHubAPITests
+//
+//  Created by Philip Willoughby on 29/04/2011.
+//  Copyright 2011 StrawberryCat. All rights reserved.
+//
+
+#import "UAGitHubAPITests.h"
+
+
+@implementation UAGitHubAPITests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+    
+    [super tearDown];
+}
+
+- (void)testExample
+{
+    STFail(@"Unit tests are not implemented yet in UAGitHubAPITests");
+}
+
+@end

--- a/UAGitHubAPITests/en.lproj/InfoPlist.strings
+++ b/UAGitHubAPITests/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/UAGithubEngine.m
+++ b/UAGithubEngine.m
@@ -661,7 +661,7 @@
     
     // Get response code.
     NSHTTPURLResponse *resp = (NSHTTPURLResponse *)response;
-    int statusCode = resp.statusCode;
+    NSInteger statusCode = resp.statusCode;
 	
 	
 	if ([[[resp allHeaderFields] allKeys] containsObject:@"X-Ratelimit-Remaining"] && [[[resp allHeaderFields] valueForKey:@"X-Ratelimit-Remaining"] isEqualToString:@"1"])

--- a/UAGithubEngine.xcodeproj/project.pbxproj
+++ b/UAGithubEngine.xcodeproj/project.pbxproj
@@ -725,6 +725,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				INFOPLIST_FILE = "UAGitHubAPI/UAGitHubAPI-Info.plist";
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
@@ -849,7 +850,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PREBINDING = NO;
 				SDKROOT = macosx10.6;
 			};
@@ -865,6 +866,7 @@
 				A17ECFAB136B58F5008A7FCD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		A17ECFAF136B58F5008A7FCD /* Build configuration list for PBXNativeTarget "UAGitHubAPITests" */ = {
 			isa = XCConfigurationList;
@@ -873,6 +875,7 @@
 				A17ECFAD136B58F5008A7FCD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "UAGithubEngine" */ = {
 			isa = XCConfigurationList;

--- a/UAGithubEngine.xcodeproj/project.pbxproj
+++ b/UAGithubEngine.xcodeproj/project.pbxproj
@@ -9,36 +9,82 @@
 /* Begin PBXBuildFile section */
 		1DDD58160DA1D0A300B32029 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1DDD58140DA1D0A300B32029 /* MainMenu.xib */; };
 		256AC3DA0F4B6AC300CF3369 /* AppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 256AC3D90F4B6AC300CF3369 /* AppController.m */; };
-		681F4112134C911A002DD87D /* UAGithubEngineConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 681F4111134C911A002DD87D /* UAGithubEngineConstants.m */; };
-		681F4114134C9310002DD87D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 681F4113134C9310002DD87D /* SystemConfiguration.framework */; };
-		6839D05711FE2AED009AB715 /* CDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D03F11FE2AED009AB715 /* CDataScanner.m */; };
-		6839D05911FE2AED009AB715 /* CDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04511FE2AED009AB715 /* CDataScanner_Extensions.m */; };
-		6839D05A11FE2AED009AB715 /* NSCharacterSet_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04711FE2AED009AB715 /* NSCharacterSet_Extensions.m */; };
-		6839D05B11FE2AED009AB715 /* NSDictionary_JSONExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04911FE2AED009AB715 /* NSDictionary_JSONExtensions.m */; };
-		6839D05C11FE2AED009AB715 /* NSScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04B11FE2AED009AB715 /* NSScanner_Extensions.m */; };
-		6839D05D11FE2AED009AB715 /* CJSONDataSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04E11FE2AED009AB715 /* CJSONDataSerializer.m */; };
-		6839D05E11FE2AED009AB715 /* CJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D05011FE2AED009AB715 /* CJSONDeserializer.m */; };
-		6839D05F11FE2AED009AB715 /* CJSONScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D05211FE2AED009AB715 /* CJSONScanner.m */; };
-		6839D06011FE2AED009AB715 /* CJSONSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D05411FE2AED009AB715 /* CJSONSerializer.m */; };
-		6839D06111FE2AED009AB715 /* CSerializedJSONData.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D05611FE2AED009AB715 /* CSerializedJSONData.m */; };
-		6879AB6611FF0FAA00F29BDE /* UAGithubJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 6879AB6511FF0FAA00F29BDE /* UAGithubJSONParser.m */; };
-		6879AB6D11FF145200F29BDE /* UAGithubUsersJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 6879AB6C11FF145200F29BDE /* UAGithubUsersJSONParser.m */; };
-		6879ABB011FF40E800F29BDE /* UAGithubRepositoriesJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 6879ABAF11FF40E800F29BDE /* UAGithubRepositoriesJSONParser.m */; };
-		6879AC0111FF43DA00F29BDE /* NSArray+Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 6879AC0011FF43DA00F29BDE /* NSArray+Utilities.m */; };
-		688ECC8F1200A9240087ADB3 /* UAGithubIssuesJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 688ECC8E1200A9240087ADB3 /* UAGithubIssuesJSONParser.m */; };
-		688ECC921200A9350087ADB3 /* UAGithubIssueCommentsJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 688ECC911200A9350087ADB3 /* UAGithubIssueCommentsJSONParser.m */; };
-		688ECC9B1200A96D0087ADB3 /* UAGithubCommitsJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 688ECC9A1200A96D0087ADB3 /* UAGithubCommitsJSONParser.m */; };
-		68971F9E12105743002E7C47 /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 68971F9D12105743002E7C47 /* NSData+Base64.m */; };
-		68AEDF28116E46B20018E490 /* NSString+UAGithubEngineUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 68AEDF27116E46B20018E490 /* NSString+UAGithubEngineUtilities.m */; };
-		68C9408312DBBB6500BF1151 /* UAReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 68C9408212DBBB6500BF1151 /* UAReachability.m */; };
-		68D35B121186049900C6E37E /* UAGithubURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 68D35B111186049900C6E37E /* UAGithubURLConnection.m */; };
-		68D35B191186070300C6E37E /* NSString+UUID.m in Sources */ = {isa = PBXBuildFile; fileRef = 68D35B181186070300C6E37E /* NSString+UUID.m */; };
-		68DEB62B1207334800A9C0C2 /* UAGithubSimpleJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 68DEB62A1207334800A9C0C2 /* UAGithubSimpleJSONParser.m */; };
-		68E72AE2116653770069B287 /* UAGithubEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 68E72AE1116653770069B287 /* UAGithubEngine.m */; };
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		A17ECF8C136B58F5008A7FCD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17ECF8B136B58F5008A7FCD /* Cocoa.framework */; };
+		A17ECF93136B58F5008A7FCD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A17ECF91136B58F5008A7FCD /* InfoPlist.strings */; };
+		A17ECF9B136B58F5008A7FCD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17ECF8B136B58F5008A7FCD /* Cocoa.framework */; };
+		A17ECF9E136B58F5008A7FCD /* UAGitHubAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17ECF8A136B58F4008A7FCD /* UAGitHubAPI.framework */; };
+		A17ECFA4136B58F5008A7FCD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A17ECFA2136B58F5008A7FCD /* InfoPlist.strings */; };
+		A17ECFA7136B58F5008A7FCD /* UAGitHubAPITests.h in Resources */ = {isa = PBXBuildFile; fileRef = A17ECFA6136B58F5008A7FCD /* UAGitHubAPITests.h */; };
+		A17ECFA9136B58F5008A7FCD /* UAGitHubAPITests.m in Sources */ = {isa = PBXBuildFile; fileRef = A17ECFA8136B58F5008A7FCD /* UAGitHubAPITests.m */; };
+		A17ECFB1136B59DE008A7FCD /* UAGithubURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 68D35B101186049900C6E37E /* UAGithubURLConnection.h */; };
+		A17ECFB2136B59F3008A7FCD /* UAGithubEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 68E72AE0116653770069B287 /* UAGithubEngine.h */; };
+		A17ECFB3136B59F3008A7FCD /* UAGithubEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 68E72AE1116653770069B287 /* UAGithubEngine.m */; };
+		A17ECFB4136B59F3008A7FCD /* UAReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 68C9408112DBBB6500BF1151 /* UAReachability.h */; };
+		A17ECFB5136B59F3008A7FCD /* UAReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 68C9408212DBBB6500BF1151 /* UAReachability.m */; };
+		A17ECFB6136B59F3008A7FCD /* UAGithubEngineDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 68E72ADC116652450069B287 /* UAGithubEngineDelegate.h */; };
+		A17ECFB7136B59F3008A7FCD /* UAGithubEngineRequestTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 6852614E116A51A8003AE003 /* UAGithubEngineRequestTypes.h */; };
+		A17ECFB8136B59F3008A7FCD /* UAGithubParserDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 685261E1116A774C003AE003 /* UAGithubParserDelegate.h */; };
+		A17ECFB9136B59F3008A7FCD /* UAGithubURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 68D35B111186049900C6E37E /* UAGithubURLConnection.m */; };
+		A17ECFBA136B59F3008A7FCD /* UAGithubEngineConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 681F4110134C911A002DD87D /* UAGithubEngineConstants.h */; };
+		A17ECFBB136B59F3008A7FCD /* UAGithubEngineConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 681F4111134C911A002DD87D /* UAGithubEngineConstants.m */; };
+		A17ECFBC136B59F8008A7FCD /* NSData+Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 68971F9C12105743002E7C47 /* NSData+Base64.h */; };
+		A17ECFBD136B59F8008A7FCD /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 68971F9D12105743002E7C47 /* NSData+Base64.m */; };
+		A17ECFBE136B59F8008A7FCD /* NSString+UAGithubEngineUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 68AEDF26116E46B20018E490 /* NSString+UAGithubEngineUtilities.h */; };
+		A17ECFBF136B59F8008A7FCD /* NSString+UAGithubEngineUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 68AEDF27116E46B20018E490 /* NSString+UAGithubEngineUtilities.m */; };
+		A17ECFC0136B59F8008A7FCD /* NSString+UUID.h in Headers */ = {isa = PBXBuildFile; fileRef = 68D35B171186070300C6E37E /* NSString+UUID.h */; };
+		A17ECFC1136B59F8008A7FCD /* NSString+UUID.m in Sources */ = {isa = PBXBuildFile; fileRef = 68D35B181186070300C6E37E /* NSString+UUID.m */; };
+		A17ECFC2136B59F8008A7FCD /* NSArray+Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 6879ABFF11FF43DA00F29BDE /* NSArray+Utilities.h */; };
+		A17ECFC3136B59F8008A7FCD /* NSArray+Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 6879AC0011FF43DA00F29BDE /* NSArray+Utilities.m */; };
+		A17ECFC4136B59FE008A7FCD /* CDataScanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D03E11FE2AED009AB715 /* CDataScanner.h */; };
+		A17ECFC5136B59FE008A7FCD /* CDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D03F11FE2AED009AB715 /* CDataScanner.m */; };
+		A17ECFC6136B5A03008A7FCD /* CDataScanner_Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D04411FE2AED009AB715 /* CDataScanner_Extensions.h */; };
+		A17ECFC7136B5A03008A7FCD /* CDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04511FE2AED009AB715 /* CDataScanner_Extensions.m */; };
+		A17ECFC8136B5A03008A7FCD /* NSCharacterSet_Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D04611FE2AED009AB715 /* NSCharacterSet_Extensions.h */; };
+		A17ECFC9136B5A03008A7FCD /* NSCharacterSet_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04711FE2AED009AB715 /* NSCharacterSet_Extensions.m */; };
+		A17ECFCA136B5A03008A7FCD /* NSDictionary_JSONExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D04811FE2AED009AB715 /* NSDictionary_JSONExtensions.h */; };
+		A17ECFCB136B5A03008A7FCD /* NSDictionary_JSONExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04911FE2AED009AB715 /* NSDictionary_JSONExtensions.m */; };
+		A17ECFCC136B5A03008A7FCD /* NSScanner_Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D04A11FE2AED009AB715 /* NSScanner_Extensions.h */; };
+		A17ECFCD136B5A03008A7FCD /* NSScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04B11FE2AED009AB715 /* NSScanner_Extensions.m */; };
+		A17ECFCE136B5A0B008A7FCD /* CJSONDataSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D04D11FE2AED009AB715 /* CJSONDataSerializer.h */; };
+		A17ECFCF136B5A0B008A7FCD /* CJSONDataSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D04E11FE2AED009AB715 /* CJSONDataSerializer.m */; };
+		A17ECFD0136B5A0B008A7FCD /* CJSONDeserializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D04F11FE2AED009AB715 /* CJSONDeserializer.h */; };
+		A17ECFD1136B5A0B008A7FCD /* CJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D05011FE2AED009AB715 /* CJSONDeserializer.m */; };
+		A17ECFD2136B5A0B008A7FCD /* CJSONScanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D05111FE2AED009AB715 /* CJSONScanner.h */; };
+		A17ECFD3136B5A0B008A7FCD /* CJSONScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D05211FE2AED009AB715 /* CJSONScanner.m */; };
+		A17ECFD4136B5A0B008A7FCD /* CJSONSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D05311FE2AED009AB715 /* CJSONSerializer.h */; };
+		A17ECFD5136B5A0B008A7FCD /* CJSONSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D05411FE2AED009AB715 /* CJSONSerializer.m */; };
+		A17ECFD6136B5A0B008A7FCD /* CSerializedJSONData.h in Headers */ = {isa = PBXBuildFile; fileRef = 6839D05511FE2AED009AB715 /* CSerializedJSONData.h */; };
+		A17ECFD7136B5A0B008A7FCD /* CSerializedJSONData.m in Sources */ = {isa = PBXBuildFile; fileRef = 6839D05611FE2AED009AB715 /* CSerializedJSONData.m */; };
+		A17ECFD8136B5A0B008A7FCD /* UAGithubJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 6879AB6411FF0FAA00F29BDE /* UAGithubJSONParser.h */; };
+		A17ECFD9136B5A0B008A7FCD /* UAGithubJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 6879AB6511FF0FAA00F29BDE /* UAGithubJSONParser.m */; };
+		A17ECFDA136B5A0B008A7FCD /* UAGithubSimpleJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 68DEB6291207334800A9C0C2 /* UAGithubSimpleJSONParser.h */; };
+		A17ECFDB136B5A0B008A7FCD /* UAGithubSimpleJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 68DEB62A1207334800A9C0C2 /* UAGithubSimpleJSONParser.m */; };
+		A17ECFDC136B5A0B008A7FCD /* UAGithubUsersJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 6879AB6B11FF145200F29BDE /* UAGithubUsersJSONParser.h */; };
+		A17ECFDD136B5A0B008A7FCD /* UAGithubUsersJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 6879AB6C11FF145200F29BDE /* UAGithubUsersJSONParser.m */; };
+		A17ECFDE136B5A0B008A7FCD /* UAGithubRepositoriesJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 6879ABAE11FF40E800F29BDE /* UAGithubRepositoriesJSONParser.h */; };
+		A17ECFDF136B5A0B008A7FCD /* UAGithubRepositoriesJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 6879ABAF11FF40E800F29BDE /* UAGithubRepositoriesJSONParser.m */; };
+		A17ECFE0136B5A0B008A7FCD /* UAGithubCommitsJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 688ECC991200A96D0087ADB3 /* UAGithubCommitsJSONParser.h */; };
+		A17ECFE1136B5A0B008A7FCD /* UAGithubCommitsJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 688ECC9A1200A96D0087ADB3 /* UAGithubCommitsJSONParser.m */; };
+		A17ECFE2136B5A0B008A7FCD /* UAGithubIssuesJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 688ECC8D1200A9240087ADB3 /* UAGithubIssuesJSONParser.h */; };
+		A17ECFE3136B5A0B008A7FCD /* UAGithubIssuesJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 688ECC8E1200A9240087ADB3 /* UAGithubIssuesJSONParser.m */; };
+		A17ECFE4136B5A0B008A7FCD /* UAGithubIssueCommentsJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 688ECC901200A9350087ADB3 /* UAGithubIssueCommentsJSONParser.h */; };
+		A17ECFE5136B5A0B008A7FCD /* UAGithubIssueCommentsJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 688ECC911200A9350087ADB3 /* UAGithubIssueCommentsJSONParser.m */; };
+		A17ECFE6136B5A67008A7FCD /* UAGitHubAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17ECF8A136B58F4008A7FCD /* UAGitHubAPI.framework */; };
+		A17ECFE7136B5B51008A7FCD /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 681F4113134C9310002DD87D /* SystemConfiguration.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A17ECF9C136B58F5008A7FCD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A17ECF89136B58F4008A7FCD;
+			remoteInfo = UAGitHubAPI;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -106,6 +152,18 @@
 		68E72AE1116653770069B287 /* UAGithubEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UAGithubEngine.m; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* UAGithubEngine-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "UAGithubEngine-Info.plist"; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* UAGithubEngine.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UAGithubEngine.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A17ECF8A136B58F4008A7FCD /* UAGitHubAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UAGitHubAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A17ECF8B136B58F5008A7FCD /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		A17ECF8D136B58F5008A7FCD /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		A17ECF90136B58F5008A7FCD /* UAGitHubAPI-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "UAGitHubAPI-Info.plist"; sourceTree = "<group>"; };
+		A17ECF92136B58F5008A7FCD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		A17ECF94136B58F5008A7FCD /* UAGitHubAPI-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UAGitHubAPI-Prefix.pch"; sourceTree = "<group>"; };
+		A17ECF9A136B58F5008A7FCD /* UAGitHubAPITests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UAGitHubAPITests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A17ECFA1136B58F5008A7FCD /* UAGitHubAPITests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "UAGitHubAPITests-Info.plist"; sourceTree = "<group>"; };
+		A17ECFA3136B58F5008A7FCD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		A17ECFA5136B58F5008A7FCD /* UAGitHubAPITests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UAGitHubAPITests-Prefix.pch"; sourceTree = "<group>"; };
+		A17ECFA6136B58F5008A7FCD /* UAGitHubAPITests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UAGitHubAPITests.h; sourceTree = "<group>"; };
+		A17ECFA8136B58F5008A7FCD /* UAGitHubAPITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UAGitHubAPITests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,8 +171,26 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				681F4114134C9310002DD87D /* SystemConfiguration.framework in Frameworks */,
+				A17ECFE6136B5A67008A7FCD /* UAGitHubAPI.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A17ECF86136B58F4008A7FCD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17ECF8C136B58F5008A7FCD /* Cocoa.framework in Frameworks */,
+				A17ECFE7136B5B51008A7FCD /* SystemConfiguration.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A17ECF96136B58F5008A7FCD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17ECF9B136B58F5008A7FCD /* Cocoa.framework in Frameworks */,
+				A17ECF9E136B58F5008A7FCD /* UAGitHubAPI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,6 +220,7 @@
 				681F4113134C9310002DD87D /* SystemConfiguration.framework */,
 				29B97324FDCFA39411CA2CEA /* AppKit.framework */,
 				29B97325FDCFA39411CA2CEA /* Foundation.framework */,
+				A17ECF8D136B58F5008A7FCD /* CoreData.framework */,
 			);
 			name = "Other Frameworks";
 			sourceTree = "<group>";
@@ -152,6 +229,7 @@
 			isa = PBXGroup;
 			children = (
 				8D1107320486CEB800E47090 /* UAGithubEngine.app */,
+				A17ECF9A136B58F5008A7FCD /* UAGitHubAPITests.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -159,9 +237,12 @@
 		29B97314FDCFA39411CA2CEA /* UAGithubEngine */ = {
 			isa = PBXGroup;
 			children = (
+				A17ECF8A136B58F4008A7FCD /* UAGitHubAPI.framework */,
 				080E96DDFE201D6D7F000001 /* Classes */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
+				A17ECF8E136B58F5008A7FCD /* UAGitHubAPI */,
+				A17ECF9F136B58F5008A7FCD /* UAGitHubAPITests */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
 			);
@@ -191,6 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
+				A17ECF8B136B58F5008A7FCD /* Cocoa.framework */,
 				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
 			);
 			name = Frameworks;
@@ -305,7 +387,83 @@
 			name = Engine;
 			sourceTree = "<group>";
 		};
+		A17ECF8E136B58F5008A7FCD /* UAGitHubAPI */ = {
+			isa = PBXGroup;
+			children = (
+				A17ECF8F136B58F5008A7FCD /* Supporting Files */,
+			);
+			path = UAGitHubAPI;
+			sourceTree = "<group>";
+		};
+		A17ECF8F136B58F5008A7FCD /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				A17ECF90136B58F5008A7FCD /* UAGitHubAPI-Info.plist */,
+				A17ECF91136B58F5008A7FCD /* InfoPlist.strings */,
+				A17ECF94136B58F5008A7FCD /* UAGitHubAPI-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		A17ECF9F136B58F5008A7FCD /* UAGitHubAPITests */ = {
+			isa = PBXGroup;
+			children = (
+				A17ECFA6136B58F5008A7FCD /* UAGitHubAPITests.h */,
+				A17ECFA8136B58F5008A7FCD /* UAGitHubAPITests.m */,
+				A17ECFA0136B58F5008A7FCD /* Supporting Files */,
+			);
+			path = UAGitHubAPITests;
+			sourceTree = "<group>";
+		};
+		A17ECFA0136B58F5008A7FCD /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				A17ECFA1136B58F5008A7FCD /* UAGitHubAPITests-Info.plist */,
+				A17ECFA2136B58F5008A7FCD /* InfoPlist.strings */,
+				A17ECFA5136B58F5008A7FCD /* UAGitHubAPITests-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		A17ECF87136B58F4008A7FCD /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17ECFB1136B59DE008A7FCD /* UAGithubURLConnection.h in Headers */,
+				A17ECFB2136B59F3008A7FCD /* UAGithubEngine.h in Headers */,
+				A17ECFB4136B59F3008A7FCD /* UAReachability.h in Headers */,
+				A17ECFB6136B59F3008A7FCD /* UAGithubEngineDelegate.h in Headers */,
+				A17ECFB7136B59F3008A7FCD /* UAGithubEngineRequestTypes.h in Headers */,
+				A17ECFB8136B59F3008A7FCD /* UAGithubParserDelegate.h in Headers */,
+				A17ECFBA136B59F3008A7FCD /* UAGithubEngineConstants.h in Headers */,
+				A17ECFBC136B59F8008A7FCD /* NSData+Base64.h in Headers */,
+				A17ECFBE136B59F8008A7FCD /* NSString+UAGithubEngineUtilities.h in Headers */,
+				A17ECFC0136B59F8008A7FCD /* NSString+UUID.h in Headers */,
+				A17ECFC2136B59F8008A7FCD /* NSArray+Utilities.h in Headers */,
+				A17ECFC4136B59FE008A7FCD /* CDataScanner.h in Headers */,
+				A17ECFC6136B5A03008A7FCD /* CDataScanner_Extensions.h in Headers */,
+				A17ECFC8136B5A03008A7FCD /* NSCharacterSet_Extensions.h in Headers */,
+				A17ECFCA136B5A03008A7FCD /* NSDictionary_JSONExtensions.h in Headers */,
+				A17ECFCC136B5A03008A7FCD /* NSScanner_Extensions.h in Headers */,
+				A17ECFCE136B5A0B008A7FCD /* CJSONDataSerializer.h in Headers */,
+				A17ECFD0136B5A0B008A7FCD /* CJSONDeserializer.h in Headers */,
+				A17ECFD2136B5A0B008A7FCD /* CJSONScanner.h in Headers */,
+				A17ECFD4136B5A0B008A7FCD /* CJSONSerializer.h in Headers */,
+				A17ECFD6136B5A0B008A7FCD /* CSerializedJSONData.h in Headers */,
+				A17ECFD8136B5A0B008A7FCD /* UAGithubJSONParser.h in Headers */,
+				A17ECFDA136B5A0B008A7FCD /* UAGithubSimpleJSONParser.h in Headers */,
+				A17ECFDC136B5A0B008A7FCD /* UAGithubUsersJSONParser.h in Headers */,
+				A17ECFDE136B5A0B008A7FCD /* UAGithubRepositoriesJSONParser.h in Headers */,
+				A17ECFE0136B5A0B008A7FCD /* UAGithubCommitsJSONParser.h in Headers */,
+				A17ECFE2136B5A0B008A7FCD /* UAGithubIssuesJSONParser.h in Headers */,
+				A17ECFE4136B5A0B008A7FCD /* UAGithubIssueCommentsJSONParser.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		8D1107260486CEB800E47090 /* UAGithubEngine */ = {
@@ -326,6 +484,43 @@
 			productReference = 8D1107320486CEB800E47090 /* UAGithubEngine.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A17ECF89136B58F4008A7FCD /* UAGitHubAPI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A17ECFAE136B58F5008A7FCD /* Build configuration list for PBXNativeTarget "UAGitHubAPI" */;
+			buildPhases = (
+				A17ECF85136B58F4008A7FCD /* Sources */,
+				A17ECF86136B58F4008A7FCD /* Frameworks */,
+				A17ECF87136B58F4008A7FCD /* Headers */,
+				A17ECF88136B58F4008A7FCD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = UAGitHubAPI;
+			productName = UAGitHubAPI;
+			productReference = A17ECF8A136B58F4008A7FCD /* UAGitHubAPI.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		A17ECF99136B58F5008A7FCD /* UAGitHubAPITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A17ECFAF136B58F5008A7FCD /* Build configuration list for PBXNativeTarget "UAGitHubAPITests" */;
+			buildPhases = (
+				A17ECF95136B58F5008A7FCD /* Sources */,
+				A17ECF96136B58F5008A7FCD /* Frameworks */,
+				A17ECF97136B58F5008A7FCD /* Resources */,
+				A17ECF98136B58F5008A7FCD /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A17ECF9D136B58F5008A7FCD /* PBXTargetDependency */,
+			);
+			name = UAGitHubAPITests;
+			productName = UAGitHubAPITests;
+			productReference = A17ECF9A136B58F5008A7FCD /* UAGitHubAPITests.octest */;
+			productType = "com.apple.product-type.bundle";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -343,6 +538,8 @@
 			projectRoot = "";
 			targets = (
 				8D1107260486CEB800E47090 /* UAGithubEngine */,
+				A17ECF89136B58F4008A7FCD /* UAGitHubAPI */,
+				A17ECF99136B58F5008A7FCD /* UAGitHubAPITests */,
 			);
 		};
 /* End PBXProject section */
@@ -357,7 +554,40 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A17ECF88136B58F4008A7FCD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17ECF93136B58F5008A7FCD /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A17ECF97136B58F5008A7FCD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17ECFA4136B58F5008A7FCD /* InfoPlist.strings in Resources */,
+				A17ECFA7136B58F5008A7FCD /* UAGitHubAPITests.h in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A17ECF98136B58F5008A7FCD /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8D11072C0486CEB800E47090 /* Sources */ = {
@@ -366,35 +596,58 @@
 			files = (
 				8D11072D0486CEB800E47090 /* main.m in Sources */,
 				256AC3DA0F4B6AC300CF3369 /* AppController.m in Sources */,
-				68E72AE2116653770069B287 /* UAGithubEngine.m in Sources */,
-				68AEDF28116E46B20018E490 /* NSString+UAGithubEngineUtilities.m in Sources */,
-				68D35B121186049900C6E37E /* UAGithubURLConnection.m in Sources */,
-				68D35B191186070300C6E37E /* NSString+UUID.m in Sources */,
-				6839D05711FE2AED009AB715 /* CDataScanner.m in Sources */,
-				6839D05911FE2AED009AB715 /* CDataScanner_Extensions.m in Sources */,
-				6839D05A11FE2AED009AB715 /* NSCharacterSet_Extensions.m in Sources */,
-				6839D05B11FE2AED009AB715 /* NSDictionary_JSONExtensions.m in Sources */,
-				6839D05C11FE2AED009AB715 /* NSScanner_Extensions.m in Sources */,
-				6839D05D11FE2AED009AB715 /* CJSONDataSerializer.m in Sources */,
-				6839D05E11FE2AED009AB715 /* CJSONDeserializer.m in Sources */,
-				6839D05F11FE2AED009AB715 /* CJSONScanner.m in Sources */,
-				6839D06011FE2AED009AB715 /* CJSONSerializer.m in Sources */,
-				6839D06111FE2AED009AB715 /* CSerializedJSONData.m in Sources */,
-				6879AB6611FF0FAA00F29BDE /* UAGithubJSONParser.m in Sources */,
-				6879AB6D11FF145200F29BDE /* UAGithubUsersJSONParser.m in Sources */,
-				6879ABB011FF40E800F29BDE /* UAGithubRepositoriesJSONParser.m in Sources */,
-				6879AC0111FF43DA00F29BDE /* NSArray+Utilities.m in Sources */,
-				688ECC8F1200A9240087ADB3 /* UAGithubIssuesJSONParser.m in Sources */,
-				688ECC921200A9350087ADB3 /* UAGithubIssueCommentsJSONParser.m in Sources */,
-				688ECC9B1200A96D0087ADB3 /* UAGithubCommitsJSONParser.m in Sources */,
-				68DEB62B1207334800A9C0C2 /* UAGithubSimpleJSONParser.m in Sources */,
-				68971F9E12105743002E7C47 /* NSData+Base64.m in Sources */,
-				68C9408312DBBB6500BF1151 /* UAReachability.m in Sources */,
-				681F4112134C911A002DD87D /* UAGithubEngineConstants.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A17ECF85136B58F4008A7FCD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17ECFB3136B59F3008A7FCD /* UAGithubEngine.m in Sources */,
+				A17ECFB5136B59F3008A7FCD /* UAReachability.m in Sources */,
+				A17ECFB9136B59F3008A7FCD /* UAGithubURLConnection.m in Sources */,
+				A17ECFBB136B59F3008A7FCD /* UAGithubEngineConstants.m in Sources */,
+				A17ECFBD136B59F8008A7FCD /* NSData+Base64.m in Sources */,
+				A17ECFBF136B59F8008A7FCD /* NSString+UAGithubEngineUtilities.m in Sources */,
+				A17ECFC1136B59F8008A7FCD /* NSString+UUID.m in Sources */,
+				A17ECFC3136B59F8008A7FCD /* NSArray+Utilities.m in Sources */,
+				A17ECFC5136B59FE008A7FCD /* CDataScanner.m in Sources */,
+				A17ECFC7136B5A03008A7FCD /* CDataScanner_Extensions.m in Sources */,
+				A17ECFC9136B5A03008A7FCD /* NSCharacterSet_Extensions.m in Sources */,
+				A17ECFCB136B5A03008A7FCD /* NSDictionary_JSONExtensions.m in Sources */,
+				A17ECFCD136B5A03008A7FCD /* NSScanner_Extensions.m in Sources */,
+				A17ECFCF136B5A0B008A7FCD /* CJSONDataSerializer.m in Sources */,
+				A17ECFD1136B5A0B008A7FCD /* CJSONDeserializer.m in Sources */,
+				A17ECFD3136B5A0B008A7FCD /* CJSONScanner.m in Sources */,
+				A17ECFD5136B5A0B008A7FCD /* CJSONSerializer.m in Sources */,
+				A17ECFD7136B5A0B008A7FCD /* CSerializedJSONData.m in Sources */,
+				A17ECFD9136B5A0B008A7FCD /* UAGithubJSONParser.m in Sources */,
+				A17ECFDB136B5A0B008A7FCD /* UAGithubSimpleJSONParser.m in Sources */,
+				A17ECFDD136B5A0B008A7FCD /* UAGithubUsersJSONParser.m in Sources */,
+				A17ECFDF136B5A0B008A7FCD /* UAGithubRepositoriesJSONParser.m in Sources */,
+				A17ECFE1136B5A0B008A7FCD /* UAGithubCommitsJSONParser.m in Sources */,
+				A17ECFE3136B5A0B008A7FCD /* UAGithubIssuesJSONParser.m in Sources */,
+				A17ECFE5136B5A0B008A7FCD /* UAGithubIssueCommentsJSONParser.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A17ECF95136B58F5008A7FCD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17ECFA9136B58F5008A7FCD /* UAGitHubAPITests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A17ECF9D136B58F5008A7FCD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A17ECF89136B58F4008A7FCD /* UAGitHubAPI */;
+			targetProxy = A17ECF9C136B58F5008A7FCD /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		089C165CFE840E0CC02AAC07 /* InfoPlist.strings */ = {
@@ -413,9 +666,121 @@
 			name = MainMenu.xib;
 			sourceTree = "<group>";
 		};
+		A17ECF91136B58F5008A7FCD /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A17ECF92136B58F5008A7FCD /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		A17ECFA2136B58F5008A7FCD /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A17ECFA3136B58F5008A7FCD /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		A17ECFAA136B58F5008A7FCD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "UAGitHubAPI/UAGitHubAPI-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				INFOPLIST_FILE = "UAGitHubAPI/UAGitHubAPI-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Debug;
+		};
+		A17ECFAB136B58F5008A7FCD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "UAGitHubAPI/UAGitHubAPI-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				INFOPLIST_FILE = "UAGitHubAPI/UAGitHubAPI-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Release;
+		};
+		A17ECFAC136B58F5008A7FCD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "UAGitHubAPITests/UAGitHubAPITests-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				INFOPLIST_FILE = "UAGitHubAPITests/UAGitHubAPITests-Info.plist";
+				OTHER_LDFLAGS = (
+					"-framework",
+					SenTestingKit,
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Debug;
+		};
+		A17ECFAD136B58F5008A7FCD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "UAGitHubAPITests/UAGitHubAPITests-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				INFOPLIST_FILE = "UAGitHubAPITests/UAGitHubAPITests-Info.plist";
+				OTHER_LDFLAGS = (
+					"-framework",
+					SenTestingKit,
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Release;
+		};
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -493,6 +858,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		A17ECFAE136B58F5008A7FCD /* Build configuration list for PBXNativeTarget "UAGitHubAPI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A17ECFAA136B58F5008A7FCD /* Debug */,
+				A17ECFAB136B58F5008A7FCD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		A17ECFAF136B58F5008A7FCD /* Build configuration list for PBXNativeTarget "UAGitHubAPITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A17ECFAC136B58F5008A7FCD /* Debug */,
+				A17ECFAD136B58F5008A7FCD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "UAGithubEngine" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/UAGithubURLConnection.m
+++ b/UAGithubURLConnection.m
@@ -21,9 +21,8 @@
         identifier = [[NSString stringWithNewUUID] retain];
         requestType = reqType;
 		responseType = respType;
-    }
-	NSLog(@"New %@ connection: %@, %@", request.HTTPMethod, request, identifier);
-    
+        NSLog(@"New %@ connection: %@, %@", request.HTTPMethod, request, identifier);
+    }    
     return self;
 }
 


### PR DESCRIPTION
I changed .gitignore to be both more specific and more general.

More specific in that it will now only ignore .pbxuser, .perspective, etc if they are in a directory matching *.xcodeproj.

More general in that it will now ignore all xcode user data files whatever the user name, making it more usable for any new users who clone it.
